### PR TITLE
Exclude builds on branches other than dev and main

### DIFF
--- a/shells/vercel_ignore_build_step.sh
+++ b/shells/vercel_ignore_build_step.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "dev" ]] ; then
+  echo "Build can proceed"
+  exit 1;
+else
+  echo "Build cancelled"
+  exit 0;
+fi


### PR DESCRIPTION
The preview build should only occur when pushed to the 'dev' branch.