### PR TITLE
Fix type error and check for type errors before building

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write --ignore-path .gitignore '**/*.{js,jsx,ts,tsx,json}' && prisma format",
+    "type-check": "tsc --noEmit -p ./tsconfig.json",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",
     "db:seed": "node ./prisma/createData.js",

--- a/shells/release.sh
+++ b/shells/release.sh
@@ -18,6 +18,11 @@ git checkout dev
 
 git pull origin dev
 
+if ! npm run type-check; then
+  echo "TypeScript type checking failed. Aborting the process."
+  exit 1
+fi
+
 current_version=$(get_current_version)
 
 IFS='.' read -ra version_parts <<< "$current_version"

--- a/src/app/api/images/route.ts
+++ b/src/app/api/images/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { ActiveTabId } from "@/components/organisms/ImageGallery";
+import { ActiveTabId } from "@/app/ImageGallery";
 import prisma from "@/utils/client";
 
 const LIMIT = 9;

--- a/src/services/image.service.ts
+++ b/src/services/image.service.ts
@@ -1,4 +1,4 @@
-import { ActiveTabId } from "@/components/organisms/ImageGallery";
+import { ActiveTabId } from "@/app/ImageGallery";
 
 const IMAGES_ENDPOINT = "/api/images";
 


### PR DESCRIPTION
I fixed the type errors. Additionally, by running type checks before building, I've put preventive measures in place to ensure that there won't be build failures in the production environment during deployment.