### PR TITLE
Ignore deployment to Vercel during Storybook deployment

### DIFF
--- a/.github/workflows/storybook-release.yml
+++ b/.github/workflows/storybook-release.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build storybook
         run: npm run build-storybook
 
+      - name: Copy vercel_ignore_build_step.sh
+        run: npm run copy-vercel-deploy-ignore
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "release:patch": "bash ./shells/release.sh patch",
     "delete:branch": "git fetch -p && git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "copy-vercel-deploy-ignore": "mkdir -p ./storybook-static/shells && cp ./shells/vercel_ignore_build_step.sh ./storybook-static/shells/vercel_ignore_build_step.sh"
   },
   "dependencies": {
     "@prisma/client": "^5.3.1",


### PR DESCRIPTION
When deploying Storybook to GitHub Pages, it involves pushing to the gh-pages branch. During this process, Vercel's automatic deployment is triggered. Typically, we can avoid the deployment since we have ignore.sh, but gh-pages branch doesn't have it. Consequently, it attempts to deploy and fails. Therefore, I made modifications to include ignore.sh during the build process to prevent Vercel's automatic deployment from running.