### PR TITLE
Modify port and fix start_development.sh

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_APP_URL="http://localhost:3000"
+NEXT_PUBLIC_APP_URL="http://localhost:3002"
 DATABASE_URL="postgresql://postgres:p@ssw0rd@localhost:5434/LGTMeme_DB"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   postgres:
+    container_name: lgtmeme-postgres
     image: postgres:15-alpine
     environment:
       POSTGRES_USER: postgres

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "scripts": {
     "prepare": "panda codegen && npm run prisma:generate",
-    "dev": "rm -rf .next && next dev",
+    "dev": "rm -rf .next && next dev -p 3002",
     "dev:start": "bash ./shells/start_development.sh",
-    "docker:start": "docker compose up -d",
-    "docker:stop": "docker compose down",
+    "docker:start": "docker compose -f docker-compose.local.yml up -d",
+    "docker:stop": "docker compose -f docker-compose.local.yml down",
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",

--- a/shells/start_development.sh
+++ b/shells/start_development.sh
@@ -1,20 +1,18 @@
 #!/bin/bash
 
-function countdown() {
-    secs=$1
-    while [ $secs -gt 0 ]; do
-        echo -ne "Waiting for PostgreSQL... $secs\033[0K\r"
+function wait_for_postgresql() {
+    until docker exec lgtmeme-postgres psql -h localhost -U postgres -c '\q' &>/dev/null; do
+        echo -ne "Waiting for PostgreSQL... \033[0K\r"
         sleep 1
-        : $((secs--))
     done
     echo "Waiting for PostgreSQL... Done        "
 }
 
 npm install
 
-docker compose up -d
+npm run docker:start
 
-countdown 10
+wait_for_postgresql
 
 npm run prisma:migrate:dev
 

--- a/src/app/api/images/route.spec.ts
+++ b/src/app/api/images/route.spec.ts
@@ -16,7 +16,7 @@ describe("Image API", () => {
     test("When called with initial query, it shoule return images", async () => {
       prismaMock.image.findMany.mockResolvedValue(resImages as any);
       const req = {
-        url: "http://localhost:3000/api/images?page=0&keyword=&activeTabId=timeLine&favariteImageIds=",
+        url: "http://localhost:3002/api/images?page=0&keyword=&activeTabId=timeLine&favariteImageIds=",
       } as Request;
       const result = await GET(req);
       const { images } = await result.json();
@@ -25,7 +25,7 @@ describe("Image API", () => {
     test("When called with page, keyword, and activeTagId set in the query, it should return images", async () => {
       prismaMock.image.findMany.mockResolvedValue(resImages as any);
       const req = {
-        url: "http://localhost:3000/api/images?page=1&keyword=test&activeTabId=popular&favariteImageIds=",
+        url: "http://localhost:3002/api/images?page=1&keyword=test&activeTabId=popular&favariteImageIds=",
       } as Request;
       const result = await GET(req);
       const { images } = await result.json();
@@ -34,7 +34,7 @@ describe("Image API", () => {
     test("When called with favariteImageIds set in the query, it should return images", async () => {
       prismaMock.image.findMany.mockResolvedValue(resImages as any);
       const req = {
-        url: "http://localhost:3000/api/images?page=0&keyword=&activeTabId=favarite&favariteImageIds=1",
+        url: "http://localhost:3002/api/images?page=0&keyword=&activeTabId=favarite&favariteImageIds=1",
       } as Request;
       const result = await GET(req);
       const { images } = await result.json();
@@ -43,7 +43,7 @@ describe("Image API", () => {
     test("When an error occurs, return 500", async () => {
       prismaMock.image.findMany.mockRejectedValue(new Error());
       const req = {
-        url: "http://localhost:3000/api/images?page=0&keyword=&activeTabId=timeLine&favariteImageIds=",
+        url: "http://localhost:3002/api/images?page=0&keyword=&activeTabId=timeLine&favariteImageIds=",
       } as Request;
       const result = await GET(req);
       const status = await result.status;


### PR DESCRIPTION
I have modified the application's port number to be 3002 during development, ensuring it does not conflict with other applications. Additionally, I have updated the process to check for PostgreSQL's startup completion before executing subsequent commands like migration, rather than waiting for 10 seconds.