### PR TITLE
Remove .env from tracking

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-NEXT_PUBLIC_APP_URL="http://localhost:3002"
-DATABASE_URL="postgresql://postgres:p@ssw0rd@localhost:5434/LGTMeme_DB"

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel


### PR DESCRIPTION
I have removed the environment variables used for Supabase from tracking in Git so that I can use them in the .env file.